### PR TITLE
fix script:

### DIFF
--- a/ocrd-im6convert
+++ b/ocrd-im6convert
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -eu
+set -o pipefail
+
 which ocrd >/dev/null 2>/dev/null || { echo "ocrd not in \$PATH. Panicking"; exit 1; }
 
 SHAREDIR=$(cd $(dirname $0);pwd)
@@ -18,42 +21,62 @@ main () {
     # Describe calling script to lib.bash
     ocrd__wrap "$SHAREDIR/ocrd-tool.json" "ocrd-im6convert" "$@"
 
-    # Clone the METS
-    local working_dir=$(ocrd workspace clone "${argv[mets_file]}")
+    cd "${ocrd__argv[working_dir]}"
+    in_file_grp=${ocrd__argv[input_file_grp]}
+    out_file_grp=${ocrd__argv[output_file_grp]}
+    mkdir -p $out_file_grp
 
     # Set output extension
     local output_extension="${output_extensions[${params['output-format']}]}"
 
     # Download the files and do the conversion
-    ocrd workspace -d "$working_dir" find \
-        -G "${argv[input_file_grp]}" \
+    local IFS=$'\n'
+    files=($(ocrd workspace find \
+        -G $in_file_grp \
         -k local_filename \
         -k ID \
-        -k groupId \
-        -k mimetype \
-        --download \
-    | while read infields;do
-        echo "$infields"
-
+        -k pageId \
+        --download))
+    local IFS=$' \t\n'
+    local n=0 zeros=0000
+    for csv in "${files[@]}"; do
+        let n+=1
         # Parse comma separated fields
         local IFS=$'\t'
-        local fields=($infields)
-        local infile="${fields[0]}"
+        local fields=($csv)
+        local IFS=$' \t\n'
+
+        local in_file="${fields[0]}"
+        local in_id="${fields[1]}"
+        local pageid="${fields[2]:-}"
+
+        if ! test -f "$in_file"; then
+           echo "ERROR: input file \"$in_file\" ID=${in_id} (pageId=${pageid}) is not on disk" >&2
+           continue
+        fi
 
         # Output filename
-        local output_basename="${infile//\.[^\.]*$/}"
-        local outfile="$output_basename$output_extension"
+        local out_id="${in_id//$in_file_grp/$out_file_grp}"
+        if [ "x$out_id" = "x$in_id" ]; then
+            out_id=${out_file_grp}_${zeros:0:$((4-${#n}))}$n
+        fi
+        local out_file="$out_file_grp/${out_id}$output_extension"
 
         # Actual conversion
-        convert "$infile" "$outfile"
+        convert "$in_file" "$out_file"
 
         # Add the output files
-        ocrd workspace -d "$working_dir" add \
-            -G "${argv[output_file_grp]}" \
-            -i "${fields[1]}_TIF" \
-            -g "${fields[2]}" \
-            -m "${fields[3]}" \
-            "$outfile"
+        declare -a options
+        if [ -n "$pageid" ]; then
+            options=( -g $pageid )
+        else
+            options=()
+        fi
+        options+=( -G $out_file_grp
+                   -m "${params['output-format']}"
+                   -i "$out_id"
+                   "$out_file" )
+        ocrd workspace add "${options[@]}"
     done
 }
 


### PR DESCRIPTION
- avoid race condition between save_mets...
    - in 1st cmd of pipeline when doing `ocrd workspace find --download`
    - in 2nd cmd of pipeline when doing `ocrd workspace add`  
  ...by not using a pipeline at all!
- re-use the old file ID (if possible), but replace input with output file group
- pass on pageId, if it exists
- exit on failure